### PR TITLE
added support for ed255519 keys to MarshalPrivateKey()

### DIFF
--- a/ed25519_test.go
+++ b/ed25519_test.go
@@ -75,6 +75,16 @@ func TestMarshalLoop(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	privB, err = MarshalPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privNew, err = UnmarshalPrivateKey(privB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if !priv.Equals(privNew) || !privNew.Equals(priv) {
 		t.Fatal("keys are not equal")
 	}

--- a/key.go
+++ b/key.go
@@ -266,12 +266,15 @@ func UnmarshalPrivateKey(data []byte) (PrivKey, error) {
 
 // MarshalPrivateKey converts a key object into its protobuf serialized form.
 func MarshalPrivateKey(k PrivKey) ([]byte, error) {
-	b := MarshalRsaPrivateKey(k.(*RsaPrivateKey))
-	pmes := new(pb.PrivateKey)
-	typ := pb.KeyType_RSA // for now only type.
-	pmes.Type = &typ
-	pmes.Data = b
-	return proto.Marshal(pmes)
+
+	switch k.(type) {
+	case *Ed25519PrivateKey:
+		return k.Bytes()
+	case *RsaPrivateKey:
+		return k.Bytes()
+	default:
+		return nil, ErrBadKeyType
+	}
 }
 
 // ConfigDecodeKey decodes from b64 (for config file), and unmarshals.


### PR DESCRIPTION
MarshalPrivateKey() used to only support RSA key type, and also duplicated the marshaling implementation in the RSA Bytes() code.  This commit uses Bytes() to Marshal both types.  It could be implemented simply as a call to Bytes() but I added the type checks so that call will return the ErrBadKeyType error instead of a run-time panic if passed an incorrect type.
