### PR TITLE
Coverage Improvement

### DIFF
--- a/key.go
+++ b/key.go
@@ -32,6 +32,12 @@ const (
 	Secp256k1
 )
 
+var KeyTypes = []int{
+	RSA,
+	Ed25519,
+	Secp256k1,
+}
+
 // Key represents a crypto key that can be compared to another key
 type Key interface {
 	// Bytes returns a serialized, storeable representation of this key

--- a/key.go
+++ b/key.go
@@ -281,6 +281,8 @@ func MarshalPrivateKey(k PrivKey) ([]byte, error) {
 		return k.Bytes()
 	case *RsaPrivateKey:
 		return k.Bytes()
+	case *Secp256k1PrivateKey:
+		return k.Bytes()
 	default:
 		return nil, ErrBadKeyType
 	}

--- a/key.go
+++ b/key.go
@@ -236,9 +236,7 @@ func UnmarshalPublicKey(data []byte) (PubKey, error) {
 	case pb.KeyType_RSA:
 		return UnmarshalRsaPublicKey(pmes.GetData())
 	case pb.KeyType_Ed25519:
-		var pubk [32]byte
-		copy(pubk[:], pmes.Data)
-		return &Ed25519PublicKey{&pubk}, nil
+		return UnmarshalEd25519PublicKey(pmes.GetData())
 	case pb.KeyType_Secp256k1:
 		return UnmarshalSecp256k1PublicKey(pmes.GetData())
 	default:

--- a/key_test.go
+++ b/key_test.go
@@ -9,11 +9,18 @@ import (
 	"testing"
 )
 
-func TestRsaKeys(t *testing.T) {
-	sk, pk, err := tu.RandTestKeyPair(512)
+func TestKeys(t *testing.T) {
+	for _, typ := range KeyTypes {
+		testKeyType(typ, t)
+	}
+}
+
+func testKeyType(typ int, t *testing.T) {
+	sk, pk, err := tu.RandTestKeyPair(typ, 512)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	testKeySignature(t, sk)
 	testKeyEncoding(t, sk)
 	testKeyEquals(t, sk)
@@ -96,7 +103,7 @@ func testKeyEquals(t *testing.T, k Key) {
 		t.Fatal("Key not equal to key with same bytes.")
 	}
 
-	sk, pk, err := tu.RandTestKeyPair(512)
+	sk, pk, err := tu.RandTestKeyPair(RSA, 512)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/key_test.go
+++ b/key_test.go
@@ -59,6 +59,10 @@ func testKeyEncoding(t *testing.T, sk PrivKey) {
 		t.Fatal(err)
 	}
 
+	if !sk.Equals(sk2) {
+		t.Error("Unmarshaled private key didn't match original.\n")
+	}
+
 	skbm2, err := MarshalPrivateKey(sk2)
 	if err != nil {
 		t.Fatal(err)
@@ -74,9 +78,13 @@ func testKeyEncoding(t *testing.T, sk PrivKey) {
 		t.Fatal(err)
 	}
 
-	_, err = UnmarshalPublicKey(pkbm)
+	pk2, err := UnmarshalPublicKey(pkbm)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if !pk.Equals(pk2) {
+		t.Error("Unmarshaled public key didn't match original.\n")
 	}
 
 	pkbm2, err := MarshalPublicKey(pk)

--- a/test/utils.go
+++ b/test/utils.go
@@ -7,12 +7,11 @@ import (
 	ci "github.com/libp2p/go-libp2p-crypto"
 )
 
-func RandTestKeyPair(bits int) (ci.PrivKey, ci.PubKey, error) {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	return ci.GenerateKeyPairWithReader(ci.RSA, bits, r)
+func RandTestKeyPair(typ, bits int) (ci.PrivKey, ci.PubKey, error) {
+	return SeededTestKeyPair(typ, bits, time.Now().UnixNano())
 }
 
-func SeededTestKeyPair(seed int64) (ci.PrivKey, ci.PubKey, error) {
+func SeededTestKeyPair(typ, bits int, seed int64) (ci.PrivKey, ci.PubKey, error) {
 	r := rand.New(rand.NewSource(seed))
-	return ci.GenerateKeyPairWithReader(ci.RSA, 512, r)
+	return ci.GenerateKeyPairWithReader(typ, bits, r)
 }


### PR DESCRIPTION
It looks like key_test.go was only exercising the RSA implementation, so I modified it and the test utilities to support other key types. While testing that change I noted, and fixed, two oddities.
1) The Secp256k1PrivateKey marshaller wasn't hooked up.
2) The UnmarshalEd25519PublicKey code was duplicated. 

I also updated an existing test to exercise the key.Equals interface.