### PR TITLE
Add support for pluggable unmarshalling for any asymmetric key type

### DIFF
--- a/ed25519.go
+++ b/ed25519.go
@@ -104,7 +104,7 @@ func (k *Ed25519PublicKey) ToCurve25519() (*[32]byte, error) {
 	return &pk, nil
 }
 
-func UnmarshalEd25519PublicKey(data []byte) (*Ed25519PublicKey, error) {
+func UnmarshalEd25519PublicKey(data []byte) (PubKey, error) {
 	if len(data) != 32 {
 		return nil, fmt.Errorf("expect ed25519 public key data size to be 32")
 	}
@@ -117,7 +117,7 @@ func UnmarshalEd25519PublicKey(data []byte) (*Ed25519PublicKey, error) {
 	}, nil
 }
 
-func UnmarshalEd25519PrivateKey(data []byte) (*Ed25519PrivateKey, error) {
+func UnmarshalEd25519PrivateKey(data []byte) (PrivKey, error) {
 	if len(data) != 96 {
 		return nil, fmt.Errorf("expected ed25519 data size to be 96")
 	}

--- a/key.go
+++ b/key.go
@@ -21,13 +21,13 @@ import (
 
 	pb "github.com/libp2p/go-libp2p-crypto/pb"
 
-	proto "github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 )
 
 var ErrBadKeyType = errors.New("invalid or unsupported key type")
 
 const (
-	RSA = iota
+	RSA       = iota
 	Ed25519
 	Secp256k1
 )
@@ -228,11 +228,11 @@ func KeyStretcher(cipherType string, hashType string, secret []byte) (StretchedK
 	var k2 StretchedKeys
 
 	k1.IV = r1[0:ivSize]
-	k1.CipherKey = r1[ivSize : ivSize+cipherKeySize]
+	k1.CipherKey = r1[ivSize: ivSize+cipherKeySize]
 	k1.MacKey = r1[ivSize+cipherKeySize:]
 
 	k2.IV = r2[0:ivSize]
-	k2.CipherKey = r2[ivSize : ivSize+cipherKeySize]
+	k2.CipherKey = r2[ivSize: ivSize+cipherKeySize]
 	k2.MacKey = r2[ivSize+cipherKeySize:]
 
 	return k1, k2
@@ -247,10 +247,12 @@ func UnmarshalPublicKey(data []byte) (PubKey, error) {
 		return nil, err
 	}
 
-	if um, ok := PubKeyUnmarshallers[pmes.GetType()]; ok {
-		return um(pmes.GetData())
+	um, ok := PubKeyUnmarshallers[pmes.GetType()]
+	if !ok {
+		return nil, ErrBadKeyType
 	}
-	return nil, ErrBadKeyType
+
+	return um(pmes.GetData())
 }
 
 // MarshalPublicKey converts a public key object into a protobuf serialized
@@ -268,10 +270,12 @@ func UnmarshalPrivateKey(data []byte) (PrivKey, error) {
 		return nil, err
 	}
 
-	if um, ok := PrivKeyUnmarshallers[pmes.GetType()]; ok {
-		return um(pmes.GetData())
+	um, ok := PrivKeyUnmarshallers[pmes.GetType()]
+	if !ok {
+		return nil, ErrBadKeyType
 	}
-	return nil, ErrBadKeyType
+
+	return um(pmes.GetData())
 }
 
 // MarshalPrivateKey converts a key object into its protobuf serialized form.

--- a/key.go
+++ b/key.go
@@ -38,6 +38,21 @@ var KeyTypes = []int{
 	Secp256k1,
 }
 
+type PubKeyUnmarshaller = func(data []byte) (PubKey, error)
+type PrivKeyUnmarshaller = func(data []byte) (PrivKey, error)
+
+var PubKeyUnmarshallers = map[pb.KeyType]PubKeyUnmarshaller{
+	pb.KeyType_RSA:       UnmarshalRsaPublicKey,
+	pb.KeyType_Ed25519:   UnmarshalEd25519PublicKey,
+	pb.KeyType_Secp256k1: UnmarshalSecp256k1PublicKey,
+}
+
+var PrivKeyUnmarshallers = map[pb.KeyType]PrivKeyUnmarshaller{
+	pb.KeyType_RSA:       UnmarshalRsaPrivateKey,
+	pb.KeyType_Ed25519:   UnmarshalEd25519PrivateKey,
+	pb.KeyType_Secp256k1: UnmarshalSecp256k1PrivateKey,
+}
+
 // Key represents a crypto key that can be compared to another key
 type Key interface {
 	// Bytes returns a serialized, storeable representation of this key
@@ -232,16 +247,10 @@ func UnmarshalPublicKey(data []byte) (PubKey, error) {
 		return nil, err
 	}
 
-	switch pmes.GetType() {
-	case pb.KeyType_RSA:
-		return UnmarshalRsaPublicKey(pmes.GetData())
-	case pb.KeyType_Ed25519:
-		return UnmarshalEd25519PublicKey(pmes.GetData())
-	case pb.KeyType_Secp256k1:
-		return UnmarshalSecp256k1PublicKey(pmes.GetData())
-	default:
-		return nil, ErrBadKeyType
+	if um, ok := PubKeyUnmarshallers[pmes.GetType()]; ok {
+		return um(pmes.GetData())
 	}
+	return nil, ErrBadKeyType
 }
 
 // MarshalPublicKey converts a public key object into a protobuf serialized
@@ -259,16 +268,10 @@ func UnmarshalPrivateKey(data []byte) (PrivKey, error) {
 		return nil, err
 	}
 
-	switch pmes.GetType() {
-	case pb.KeyType_RSA:
-		return UnmarshalRsaPrivateKey(pmes.GetData())
-	case pb.KeyType_Ed25519:
-		return UnmarshalEd25519PrivateKey(pmes.GetData())
-	case pb.KeyType_Secp256k1:
-		return UnmarshalSecp256k1PrivateKey(pmes.GetData())
-	default:
-		return nil, ErrBadKeyType
+	if um, ok := PrivKeyUnmarshallers[pmes.GetType()]; ok {
+		return um(pmes.GetData())
 	}
+	return nil, ErrBadKeyType
 }
 
 // MarshalPrivateKey converts a key object into its protobuf serialized form.

--- a/key.go
+++ b/key.go
@@ -27,7 +27,7 @@ import (
 var ErrBadKeyType = errors.New("invalid or unsupported key type")
 
 const (
-	RSA       = iota
+	RSA = iota
 	Ed25519
 	Secp256k1
 )
@@ -228,11 +228,11 @@ func KeyStretcher(cipherType string, hashType string, secret []byte) (StretchedK
 	var k2 StretchedKeys
 
 	k1.IV = r1[0:ivSize]
-	k1.CipherKey = r1[ivSize: ivSize+cipherKeySize]
+	k1.CipherKey = r1[ivSize : ivSize+cipherKeySize]
 	k1.MacKey = r1[ivSize+cipherKeySize:]
 
 	k2.IV = r2[0:ivSize]
-	k2.CipherKey = r2[ivSize: ivSize+cipherKeySize]
+	k2.CipherKey = r2[ivSize : ivSize+cipherKeySize]
 	k2.MacKey = r2[ivSize+cipherKeySize:]
 
 	return k1, k2

--- a/rsa.go
+++ b/rsa.go
@@ -82,7 +82,7 @@ func (sk *RsaPrivateKey) Equals(k Key) bool {
 	return KeyEqual(sk, k)
 }
 
-func UnmarshalRsaPrivateKey(b []byte) (*RsaPrivateKey, error) {
+func UnmarshalRsaPrivateKey(b []byte) (PrivKey, error) {
 	sk, err := x509.ParsePKCS1PrivateKey(b)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func MarshalRsaPrivateKey(k *RsaPrivateKey) []byte {
 	return x509.MarshalPKCS1PrivateKey(k.sk)
 }
 
-func UnmarshalRsaPublicKey(b []byte) (*RsaPublicKey, error) {
+func UnmarshalRsaPublicKey(b []byte) (PubKey, error) {
 	pub, err := x509.ParsePKIXPublicKey(b)
 	if err != nil {
 		return nil, err

--- a/secp256k1.go
+++ b/secp256k1.go
@@ -23,7 +23,7 @@ func GenerateSecp256k1Key(src io.Reader) (PrivKey, PubKey, error) {
 	return k, k.GetPublic(), nil
 }
 
-func UnmarshalSecp256k1PrivateKey(data []byte) (*Secp256k1PrivateKey, error) {
+func UnmarshalSecp256k1PrivateKey(data []byte) (PrivKey, error) {
 	if len(data) != btcec.PrivKeyBytesLen {
 		return nil, fmt.Errorf("expected secp256k1 data size to be %d", btcec.PrivKeyBytesLen)
 	}
@@ -32,7 +32,7 @@ func UnmarshalSecp256k1PrivateKey(data []byte) (*Secp256k1PrivateKey, error) {
 	return (*Secp256k1PrivateKey)(privk), nil
 }
 
-func UnmarshalSecp256k1PublicKey(data []byte) (*Secp256k1PublicKey, error) {
+func UnmarshalSecp256k1PublicKey(data []byte) (PubKey, error) {
 	k, err := btcec.ParsePubKey(data, btcec.S256())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The `PubKey` and `PrivKey` interface do most of the work for supporting pluggable asymmetric keys.  The only problem is the `UnmarshalPublicKey` has hardcoded supported `KeyTypes` so no other `KeyTypes` can be used.  

This PR makes the UnmarshalPublicKey function dynamic by using a dictionary of unmarshalling functions instead of the hardcoded `switch`.