### PR TITLE
make our crypto faster

### DIFF
--- a/key.go
+++ b/key.go
@@ -99,6 +99,7 @@ func GenerateKeyPairWithReader(typ, bits int, src io.Reader) (PrivKey, PubKey, e
 		if err != nil {
 			return nil, nil, err
 		}
+		priv.Precompute()
 		pk := &priv.PublicKey
 		return &RsaPrivateKey{sk: priv}, &RsaPublicKey{pk}, nil
 	case Ed25519:

--- a/key.go
+++ b/key.go
@@ -15,13 +15,13 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
-	"crypto/sha256"
 	"crypto/sha512"
 	"hash"
 
 	pb "github.com/libp2p/go-libp2p-crypto/pb"
 
 	"github.com/gogo/protobuf/proto"
+	sha256 "github.com/minio/sha256-simd"
 )
 
 var ErrBadKeyType = errors.New("invalid or unsupported key type")

--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
       "hash": "QmWq5PJgAQKDWQerAijYUVKW8mN5MDatK5j7VMp8rizKQd",
       "name": "btcec",
       "version": "0.0.1"
+    },
+    {
+      "author": "minio",
+      "hash": "QmXTpwq2AkzQsPjKqFQDNY2bMdsAT53hUBETeyj8QRHTZU",
+      "name": "sha256-simd",
+      "version": "0.1.1"
     }
   ],
   "gxVersion": "0.4.0",

--- a/rsa.go
+++ b/rsa.go
@@ -87,6 +87,8 @@ func UnmarshalRsaPrivateKey(b []byte) (PrivKey, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Important for performance. Please *do not remove this*.
+	sk.Precompute()
 	return &RsaPrivateKey{sk: sk}, nil
 }
 

--- a/rsa.go
+++ b/rsa.go
@@ -4,12 +4,13 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/x509"
 	"errors"
 
-	proto "github.com/gogo/protobuf/proto"
 	pb "github.com/libp2p/go-libp2p-crypto/pb"
+
+	proto "github.com/gogo/protobuf/proto"
+	sha256 "github.com/minio/sha256-simd"
 )
 
 type RsaPrivateKey struct {

--- a/secp256k1.go
+++ b/secp256k1.go
@@ -1,13 +1,13 @@
 package crypto
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"io"
 
 	btcec "github.com/btcsuite/btcd/btcec"
 	proto "github.com/gogo/protobuf/proto"
 	pb "github.com/libp2p/go-libp2p-crypto/pb"
+	sha256 "github.com/minio/sha256-simd"
 )
 
 type Secp256k1PrivateKey btcec.PrivateKey


### PR DESCRIPTION
1. Use mineo for sha256 hashes.
2. Precompute components for RSA private keys.