### PR TITLE
Revert "precompute rsa private key params"

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.6.1: QmUDfaMUrUZtUDAEzegX8RrdpRo2RHesymmeGtd4GyZ8Uh
+1.6.2: Qme1knMqwt1hKZbc1BmQFmnm9f36nyQGwXxPGVpVJ9rMK5

--- a/key.go
+++ b/key.go
@@ -99,7 +99,6 @@ func GenerateKeyPairWithReader(typ, bits int, src io.Reader) (PrivKey, PubKey, e
 		if err != nil {
 			return nil, nil, err
 		}
-		priv.Precompute()
 		pk := &priv.PublicKey
 		return &RsaPrivateKey{sk: priv}, &RsaPublicKey{pk}, nil
 	case Ed25519:

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "license": "MIT",
   "name": "go-libp2p-crypto",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.6.1"
+  "version": "1.6.2"
 }
 

--- a/rsa.go
+++ b/rsa.go
@@ -88,8 +88,6 @@ func UnmarshalRsaPrivateKey(b []byte) (PrivKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Important for performance. Please *do not remove this*.
-	sk.Precompute()
 	return &RsaPrivateKey{sk: sk}, nil
 }
 


### PR DESCRIPTION
This reverts commit 60c773f83c60f13de9cd4ea870210fa75b6a33bd.

Apparently, this is done automatically (inside both the generator and the serialize) and my tests showing a performance improvement were just noisy. :(