### PR TITLE
switch to the go-crypto ed25519 implementation

### DIFF
--- a/ed25519_test.go
+++ b/ed25519_test.go
@@ -3,6 +3,10 @@ package crypto
 import (
 	"crypto/rand"
 	"testing"
+
+	pb "github.com/libp2p/go-libp2p-crypto/pb"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 func TestBasicSignAndVerify(t *testing.T) {
@@ -59,47 +63,66 @@ func TestSignZero(t *testing.T) {
 		t.Fatal("signature didn't match")
 	}
 }
+
 func TestMarshalLoop(t *testing.T) {
 	priv, pub, err := GenerateEd25519Key(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	privB, err := priv.Bytes()
-	if err != nil {
-		t.Fatal(err)
+	for name, f := range map[string]func() ([]byte, error){
+		"Bytes": priv.Bytes,
+		"Marshal": func() ([]byte, error) {
+			return MarshalPrivateKey(priv)
+		},
+		"NonRedundant": func() ([]byte, error) {
+			// Manually marshal a non-redundant private key to make sure it works!
+			pbmes := new(pb.PrivateKey)
+			pbmes.Type = priv.Type()
+			data, err := priv.Raw()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			pbmes.Data = data[:ed25519.PrivateKeySize]
+			return pbmes.Marshal()
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			bts, err := f()
+			if err != nil {
+				t.Fatal(err)
+			}
+			privNew, err := UnmarshalPrivateKey(bts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !priv.Equals(privNew) || !privNew.Equals(priv) {
+				t.Fatal("keys are not equal")
+			}
+		})
 	}
 
-	privNew, err := UnmarshalPrivateKey(privB)
-	if err != nil {
-		t.Fatal(err)
-	}
+	for name, f := range map[string]func() ([]byte, error){
+		"Bytes": pub.Bytes,
+		"Marshal": func() ([]byte, error) {
+			return MarshalPublicKey(pub)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			bts, err := f()
+			if err != nil {
+				t.Fatal(err)
+			}
+			pubNew, err := UnmarshalPublicKey(bts)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	privB, err = MarshalPrivateKey(priv)
-	if err != nil {
-		t.Fatal(err)
+			if !pub.Equals(pubNew) || !pubNew.Equals(pub) {
+				t.Fatal("keys are not equal")
+			}
+		})
 	}
-
-	privNew, err = UnmarshalPrivateKey(privB)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !priv.Equals(privNew) || !privNew.Equals(priv) {
-		t.Fatal("keys are not equal")
-	}
-
-	pubB, err := pub.Bytes()
-	if err != nil {
-		t.Fatal(err)
-	}
-	pubNew, err := UnmarshalPublicKey(pubB)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !pub.Equals(pubNew) || !pubNew.Equals(pub) {
-		t.Fatal("keys are not equal")
-	}
-
 }


### PR DESCRIPTION
Also correctly parse private keys that don't have a redundant public key appended. This commit doesn't change the *serialization* format for backwards compatibility but we can now do that in the future (once most users are using this version).

This *does* remove the `ToCurve25519` function as it's not in the standard Library. However:

1. Nobody's using it.
2. Users can always extract the serialized key and do this themselves (by calling `Raw()`).
3. It's not included in go-crypto.