### PR TITLE
Fix: Remove redundant Ed25519 public key (#36).

### DIFF
--- a/ed25519.go
+++ b/ed25519.go
@@ -10,17 +10,17 @@ import (
 	"golang.org/x/crypto/ed25519"
 )
 
-// Ed25519PrivateKey is an ed25519 private key
+// Ed25519PrivateKey is an ed25519 private key.
 type Ed25519PrivateKey struct {
 	k ed25519.PrivateKey
 }
 
-// Ed25519PublicKey is an ed25519 public key
+// Ed25519PublicKey is an ed25519 public key.
 type Ed25519PublicKey struct {
 	k ed25519.PublicKey
 }
 
-// GenerateEd25519Key generate a new ed25519 private and public key pair
+// GenerateEd25519Key generate a new ed25519 private and public key pair.
 func GenerateEd25519Key(src io.Reader) (PrivKey, PubKey, error) {
 	pub, priv, err := ed25519.GenerateKey(src)
 	if err != nil {
@@ -36,22 +36,24 @@ func GenerateEd25519Key(src io.Reader) (PrivKey, PubKey, error) {
 		nil
 }
 
+// Type of the private key (Ed25519).
 func (k *Ed25519PrivateKey) Type() pb.KeyType {
 	return pb.KeyType_Ed25519
 }
 
-// Bytes marshals an ed25519 private key to protobuf bytes
+// Bytes marshals an ed25519 private key to protobuf bytes.
 func (k *Ed25519PrivateKey) Bytes() ([]byte, error) {
 	return MarshalPrivateKey(k)
 }
 
+// Raw private key bytes.
 func (k *Ed25519PrivateKey) Raw() ([]byte, error) {
-	// Intentionally redundant for backwards compatibility.
-	// Issue: #36
-	// TODO: Remove the second copy of the public key at some point in the future.
-	buf := make([]byte, len(k.k)+ed25519.PublicKeySize)
+	// The Ed25519 private key contains two 32-bytes curve points, the private
+	// key and the public key.
+	// It makes it more efficient to get the public key without re-computing an
+	// elliptic curve multiplication.
+	buf := make([]byte, len(k.k))
 	copy(buf, k.k)
-	copy(buf[len(k.k):], k.pubKeyBytes())
 
 	return buf, nil
 }
@@ -60,7 +62,7 @@ func (k *Ed25519PrivateKey) pubKeyBytes() []byte {
 	return k.k[ed25519.PrivateKeySize-ed25519.PublicKeySize:]
 }
 
-// Equals compares two ed25519 private keys
+// Equals compares two ed25519 private keys.
 func (k *Ed25519PrivateKey) Equals(o Key) bool {
 	edk, ok := o.(*Ed25519PrivateKey)
 	if !ok {
@@ -70,30 +72,32 @@ func (k *Ed25519PrivateKey) Equals(o Key) bool {
 	return bytes.Equal(k.k, edk.k)
 }
 
-// GetPublic returns an ed25519 public key from a private key
+// GetPublic returns an ed25519 public key from a private key.
 func (k *Ed25519PrivateKey) GetPublic() PubKey {
 	return &Ed25519PublicKey{k: k.pubKeyBytes()}
 }
 
-// Sign returns a signature from an input message
+// Sign returns a signature from an input message.
 func (k *Ed25519PrivateKey) Sign(msg []byte) ([]byte, error) {
 	return ed25519.Sign(k.k, msg), nil
 }
 
+// Type of the public key (Ed25519).
 func (k *Ed25519PublicKey) Type() pb.KeyType {
 	return pb.KeyType_Ed25519
 }
 
-// Bytes returns a ed25519 public key as protobuf bytes
+// Bytes returns a ed25519 public key as protobuf bytes.
 func (k *Ed25519PublicKey) Bytes() ([]byte, error) {
 	return MarshalPublicKey(k)
 }
 
+// Raw public key bytes.
 func (k *Ed25519PublicKey) Raw() ([]byte, error) {
 	return k.k, nil
 }
 
-// Equals compares two ed25519 public keys
+// Equals compares two ed25519 public keys.
 func (k *Ed25519PublicKey) Equals(o Key) bool {
 	edk, ok := o.(*Ed25519PublicKey)
 	if !ok {
@@ -103,21 +107,23 @@ func (k *Ed25519PublicKey) Equals(o Key) bool {
 	return bytes.Equal(k.k, edk.k)
 }
 
-// Verify checks a signature agains the input data
+// Verify checks a signature agains the input data.
 func (k *Ed25519PublicKey) Verify(data []byte, sig []byte) (bool, error) {
 	return ed25519.Verify(k.k, data, sig), nil
 }
 
+// UnmarshalEd25519PublicKey returns a public key from input bytes.
 func UnmarshalEd25519PublicKey(data []byte) (PubKey, error) {
 	if len(data) != 32 {
 		return nil, fmt.Errorf("expect ed25519 public key data size to be 32")
 	}
+
 	return &Ed25519PublicKey{
 		k: ed25519.PublicKey(data),
 	}, nil
 }
 
-// UnmarshalEd25519PrivateKey returns a private key from input bytes
+// UnmarshalEd25519PrivateKey returns a private key from input bytes.
 func UnmarshalEd25519PrivateKey(data []byte) (PrivKey, error) {
 	switch len(data) {
 	case ed25519.PrivateKeySize + ed25519.PublicKeySize:
@@ -134,11 +140,13 @@ func UnmarshalEd25519PrivateKey(data []byte) (PrivKey, error) {
 	case ed25519.PrivateKeySize:
 	default:
 		return nil, fmt.Errorf(
-			"expected ed25519 data size to be %d or %d",
+			"expected ed25519 data size to be %d or %d, got %d",
 			ed25519.PrivateKeySize,
-			ed25519.PublicKeySize+ed25519.PublicKeySize,
+			ed25519.PrivateKeySize+ed25519.PublicKeySize,
+			len(data),
 		)
 	}
+
 	return &Ed25519PrivateKey{
 		k: ed25519.PrivateKey(data),
 	}, nil

--- a/ed25519.go
+++ b/ed25519.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 
@@ -115,7 +116,7 @@ func (k *Ed25519PublicKey) Verify(data []byte, sig []byte) (bool, error) {
 // UnmarshalEd25519PublicKey returns a public key from input bytes.
 func UnmarshalEd25519PublicKey(data []byte) (PubKey, error) {
 	if len(data) != 32 {
-		return nil, fmt.Errorf("expect ed25519 public key data size to be 32")
+		return nil, errors.New("expect ed25519 public key data size to be 32")
 	}
 
 	return &Ed25519PublicKey{
@@ -129,8 +130,9 @@ func UnmarshalEd25519PrivateKey(data []byte) (PrivKey, error) {
 	case ed25519.PrivateKeySize + ed25519.PublicKeySize:
 		// Remove the redundant public key. See issue #36.
 		redundantPk := data[ed25519.PrivateKeySize:]
-		if !bytes.Equal(data[len(data)-ed25519.PublicKeySize:], redundantPk) {
-			return nil, fmt.Errorf("expected redundant ed25519 public key to be redundant")
+		pk := data[ed25519.PrivateKeySize-ed25519.PublicKeySize : ed25519.PrivateKeySize]
+		if !bytes.Equal(pk, redundantPk) {
+			return nil, errors.New("expected redundant ed25519 public key to be redundant")
 		}
 
 		// No point in storing the extra data.

--- a/ed25519_test.go
+++ b/ed25519_test.go
@@ -28,7 +28,7 @@ func TestBasicSignAndVerify(t *testing.T) {
 	}
 
 	if !ok {
-		t.Fatal("signature didnt match")
+		t.Fatal("signature didn't match")
 	}
 
 	// change data
@@ -70,59 +70,82 @@ func TestMarshalLoop(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for name, f := range map[string]func() ([]byte, error){
-		"Bytes": priv.Bytes,
-		"Marshal": func() ([]byte, error) {
-			return MarshalPrivateKey(priv)
-		},
-		"NonRedundant": func() ([]byte, error) {
-			// Manually marshal a non-redundant private key to make sure it works!
-			pbmes := new(pb.PrivateKey)
-			pbmes.Type = priv.Type()
-			data, err := priv.Raw()
-			if err != nil {
-				t.Fatal(err)
-			}
+	t.Run("PrivateKey", func(t *testing.T) {
+		for name, f := range map[string]func() ([]byte, error){
+			"Bytes": priv.Bytes,
+			"Marshal": func() ([]byte, error) {
+				return MarshalPrivateKey(priv)
+			},
+			"Redundant": func() ([]byte, error) {
+				// See issue #36.
+				// Ed25519 private keys used to contain the public key twice.
+				// For backwards-compatibility, we need to continue supporting
+				// that scenario.
+				pbmes := new(pb.PrivateKey)
+				pbmes.Type = priv.Type()
+				data, err := priv.Raw()
+				if err != nil {
+					t.Fatal(err)
+				}
 
-			pbmes.Data = data[:ed25519.PrivateKeySize]
-			return pbmes.Marshal()
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			bts, err := f()
-			if err != nil {
-				t.Fatal(err)
-			}
-			privNew, err := UnmarshalPrivateKey(bts)
-			if err != nil {
-				t.Fatal(err)
-			}
+				pbmes.Data = append(data, data[len(data)-ed25519.PublicKeySize:]...)
+				return pbmes.Marshal()
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				bts, err := f()
+				if err != nil {
+					t.Fatal(err)
+				}
 
-			if !priv.Equals(privNew) || !privNew.Equals(priv) {
-				t.Fatal("keys are not equal")
-			}
-		})
-	}
+				privNew, err := UnmarshalPrivateKey(bts)
+				if err != nil {
+					t.Fatal(err)
+				}
 
-	for name, f := range map[string]func() ([]byte, error){
-		"Bytes": pub.Bytes,
-		"Marshal": func() ([]byte, error) {
-			return MarshalPublicKey(pub)
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			bts, err := f()
-			if err != nil {
-				t.Fatal(err)
-			}
-			pubNew, err := UnmarshalPublicKey(bts)
-			if err != nil {
-				t.Fatal(err)
-			}
+				if !priv.Equals(privNew) || !privNew.Equals(priv) {
+					t.Fatal("keys are not equal")
+				}
 
-			if !pub.Equals(pubNew) || !pubNew.Equals(pub) {
-				t.Fatal("keys are not equal")
-			}
-		})
-	}
+				msg := []byte("My child, my sister,\nThink of the rapture\nOf living together there!")
+				signed, err := privNew.Sign(msg)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				ok, err := privNew.GetPublic().Verify(msg, signed)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !ok {
+					t.Fatal("signature didn't match")
+				}
+			})
+		}
+	})
+
+	t.Run("PublicKey", func(t *testing.T) {
+		for name, f := range map[string]func() ([]byte, error){
+			"Bytes": pub.Bytes,
+			"Marshal": func() ([]byte, error) {
+				return MarshalPublicKey(pub)
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				bts, err := f()
+				if err != nil {
+					t.Fatal(err)
+				}
+				pubNew, err := UnmarshalPublicKey(bts)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !pub.Equals(pubNew) || !pubNew.Equals(pub) {
+					t.Fatal("keys are not equal")
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION
The private key already contains the public key point, no need to add it twice.